### PR TITLE
Closes #2

### DIFF
--- a/.phpcs.xml
+++ b/.phpcs.xml
@@ -37,4 +37,8 @@
         <severity>0</severity>
     </rule>
     <rule ref="Generic.Arrays.DisallowLongArraySyntax.Found"/>
+
+    <!-- Prevent errors caused by WordPress Coding Standards not supporting PHP 8.0+.
+    See https://github.com/WordPress/WordPress-Coding-Standards/issues/2035 -->
+    <ini name="error_reporting" value="E_ALL &#38; ~E_DEPRECATED" />
 </ruleset>


### PR DESCRIPTION
Fixed issue applying this flag in a phpcs.xml configuration file rather than on the command line, following:

```
<!--
Prevent errors caused by WordPress Coding Standards not supporting PHP 8.0+.
See https://github.com/WordPress/WordPress-Coding-Standards/issues/2035
-->
<ini name="error_reporting" value="E_ALL &#38; ~E_DEPRECATED" />
```


Ref.: https://github.com/WordPress/WordPress-Coding-Standards/issues/2035