### PR TITLE
update: phpcs rules to make wpcs ignore the build php files

### DIFF
--- a/.phpcs.xml
+++ b/.phpcs.xml
@@ -4,6 +4,7 @@
     <config name="testVersion" value="5.6-"/>
     <exclude-pattern>vendor/*</exclude-pattern>
     <exclude-pattern>node_modules/*</exclude-pattern>
+    <exclude-pattern>blocks/*/build/*</exclude-pattern>
 
     <arg value="ps"/>
     <arg name="colors"/>


### PR DESCRIPTION
Updated phpcs custom rules to ignore linting files in the build folders of each block.