### PR TITLE
refactor: renamed classes to follow PSR-1 conventions & others

### DIFF
--- a/inc/class-block-w.php
+++ b/inc/class-block-w.php
@@ -10,7 +10,7 @@ namespace XYWZBlocks\Inc;
 /**
  * Block W
  */
-class Block_W {
+class BlockW {
 
 
 	/**

--- a/inc/class-block-x.php
+++ b/inc/class-block-x.php
@@ -10,7 +10,7 @@ namespace XYWZBlocks\Inc;
 /**
  * Block X
  */
-class Block_X {
+class BlockX {
 
 
 	/**

--- a/inc/class-block-y.php
+++ b/inc/class-block-y.php
@@ -10,7 +10,7 @@ namespace XYWZBlocks\Inc;
 /**
  * Block Y
  */
-class Block_Y {
+class BlockY {
 
 
 	/**

--- a/xywz-blocks.php
+++ b/xywz-blocks.php
@@ -22,20 +22,20 @@ defined( 'ABSPATH' ) || exit;
 /**
  * Block X
  */
-require dirname( __FILE__ ) . '/inc/class-block-x.php';
-use XYWZBlocks\Inc\Block_X;
-new Block_X();
+require_once __DIR__ . '/inc/class-block-x.php';
+use XYWZBlocks\Inc\BlockX;
+new BlockX();
 
 /**
  * Block Y
  */
-require dirname( __FILE__ ) . '/inc/class-block-y.php';
-use XYWZBlocks\Inc\Block_Y;
-new Block_Y();
+require_once __DIR__ . '/inc/class-block-y.php';
+use XYWZBlocks\Inc\BlockY;
+new BlockY();
 
 /**
  * Block W
  */
-require dirname( __FILE__ ) . '/inc/class-block-w.php';
-use XYWZBlocks\Inc\Block_W;
-new Block_W();
+require_once __DIR__ . '/inc/class-block-w.php';
+use XYWZBlocks\Inc\BlockW;
+new BlockW();


### PR DESCRIPTION
- Renamed classes to follow [PSR-1 ](https://www.php-fig.org/psr/psr-1/)conventions;
- Replaced `dirname(__FILE__)` with `__DIR__` for simplicity and consistency ;
- Used `require_once ` instead of `require` to ensure that the file is only included once to avoid potential issues with redeclaration.